### PR TITLE
Fixed back button not working properly after one link is spammed

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from "redux";
 import * as authActions from "../../actions/authActions";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { NavLink } from "react-router-dom";
+import NavLinkNoDup from "../Routes/NavLinkNoDup";
 
 // Material UI Imports
 // TODO: import each component individually (i.e. '@material-ui/core/AppBar') to reduce bundle size
@@ -49,7 +49,7 @@ function Navigation(props) {
         <div className="DrawerList">
             <List className={"list"}>
                 {NavList.map((NavItem, index) => (
-                    <ListItem button key={index} component={NavLink} exact={NavItem.name === "Dashboard"} to={NavItem.link} className={"listItem"}>
+                    <ListItem button key={index} component={NavLinkNoDup} exact={NavItem.name === "Dashboard"} to={NavItem.link} className={"listItem"}>
                         <ListItemIcon className={"icon"}>{NavItem.icon}</ListItemIcon>
                         <ListItemText primary={NavItem.name} className={"text"} />
                     </ListItem>
@@ -73,7 +73,7 @@ function Navigation(props) {
                                 <MenuIcon />
                             </IconButton>
                         </Hidden>
-                        <Typography component={NavLink} to="/" className="title">
+                        <Typography component={NavLinkNoDup} to="/" className="title">
                             omou
                         </Typography>
                         <div style={{
@@ -86,7 +86,7 @@ function Navigation(props) {
                                     onClick={props.authActions.logout}>
                                     logout
                                 </Typography>
-                                : <Typography component={NavLink} to="/login" className="login">
+                                : <Typography component={NavLinkNoDup} to="/login" className="login">
                                     login
                                 </Typography>
                         }

--- a/src/components/Routes/NavLinkNoDup.js
+++ b/src/components/Routes/NavLinkNoDup.js
@@ -1,0 +1,26 @@
+import {NavLink, useLocation} from "react-router-dom";
+import React, {useCallback} from "react";
+import PropTypes from "prop-types";
+
+const NavLinkNoDup = ({to, ...rest}) => {
+    const {pathname} = useLocation();
+
+    const handleClick = useCallback((event) => {
+        if (pathname === to) {
+            event.preventDefault();
+        }
+    }, [to, pathname]);
+
+    return (
+        <NavLink
+            {...rest}
+            onClick={handleClick}
+            to={to} />
+    );
+};
+
+NavLinkNoDup.propTypes = {
+    "to": PropTypes.string.isRequired,
+};
+
+export default NavLinkNoDup;


### PR DESCRIPTION
Created a wrapper NavLink that only causes a route update if the current route differs from the target route - if you already on Accounts, clicking the Accounts tab does not flood history with that same tab over and over again. Applied this to the Navigation NavLinks.