### PR TITLE
Moved switch to top of form

### DIFF
--- a/src/components/FeatureViews/AdminPortal/AdminPanelViews.js
+++ b/src/components/FeatureViews/AdminPortal/AdminPanelViews.js
@@ -6,7 +6,7 @@ import {
 } from "react-admin";
 
 const NoneActions = props => (
-    <h1>Hi</h1>
+  <h1>Hi</h1>
 );
 
 export const CategoryList = (props) => (
@@ -112,12 +112,13 @@ const discountShowFields = [
 ];
 
 const discountEditFields = [
+  <BooleanInput key="active" source="active" />,
   <TextInput key="name" source="name" />,
   <TextInput key="description" source="description" />,
   <NumberInput key="amount" source="amount" />,
   <SelectInput choices={amountTypeChoices} key="amountType"
     source="amountType" />,
-  <BooleanInput key="active" source="active" />,
+
 ];
 
 const discountDisplays = (fields) => [


### PR DESCRIPTION
Still need to figure out how to theme react admin, but for now I've put the switch on the top of the page. The issue we are having is @neilallavarpu created dynamic buttons that render one ontop of another. The switch was part of the the top form and the imported input was on the bottom.