### PR TITLE
Action log

### DIFF
--- a/src/components/FeatureViews/AdminPortal/ActionLog.js
+++ b/src/components/FeatureViews/AdminPortal/ActionLog.js
@@ -123,7 +123,7 @@ const ActionLog = () => {
     });
     const adminOptions = ["Owner", "Receptionist", "Assistant"];
     const actionOptions = ["Add", "Edit", "Delete"]
-    const objectOptions = ["Student", "Admin", "Parent", "Instructor", "Payment", "Registration", "Tutoring", "Course", "Discount", "Price Rules"]
+    const objectOptions = ["Student", "Admin", "Parent", "Instructor", "Payment", "Registration", "Course", "Discount", "PriceRule"]
 
     if (loading) return <Loading />;
     // if (error) return <div>error</div>;


### PR DESCRIPTION
Upon testing it was found by @jsflca2012 that the Action Log object filter was broken. The following fixes should resolve this.
For ActionLog object type filter:
- Converted "Price Rules" to "pricerule"
- Removed "Tutoring" from filter