### PR TITLE
Parent registration interest

### DIFF
--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -216,7 +216,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
         })
     }
 
-    const inParentInterestList = (courseID) => {
+    const isCourseOnParentInterestList = (courseID) => {
         if (parentInterestList) {
             return parentInterestList.interests.some((interest) => interest.course.id === courseID);
         }
@@ -291,9 +291,9 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                                     >
                                         register
                                     </ResponsiveButton>
-                                    : inParentInterestList(course.id)
+                                    : isCourseOnParentInterestList(course.id)
                                         ? <ResponsiveButton
-                                            disabled={inParentInterestList(course.id)}
+                                            disabled={isCourseOnParentInterestList(course.id)}
                                             variant="outlined"
                                             onClick={handleInterestRegister(course.id)}
                                             data-cy="add-interest-button"
@@ -303,7 +303,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                                             interested
                                         </ResponsiveButton>
                                         : <ResponsiveButton
-                                            disabled={inParentInterestList(course.id)}
+                                            disabled={isCourseOnParentInterestList(course.id)}
                                             variant="outlined"
                                             onClick={handleInterestRegister(course.id)}
                                             data-cy="add-interest-button"

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -349,7 +349,10 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                 </DialogActions>
             </DialogContent>
         </Dialog>
-        <Dialog open={openInterestDialog} onClose={() => setOpenInterestDialog(false)} PaperProps={{ style: { "height": "310px", "width": "410px", "padding": "32px" } }}>
+        <Dialog 
+            open={openInterestDialog} 
+            onClose={() => setOpenInterestDialog(false)} 
+            PaperProps={{ style: { "height": "310px", "width": "410px", "padding": "32px" } }}>
                 <Grid container spacing={3}>
                     <Grid item>
                         <Typography variant="h3">Interested?</Typography>

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -130,25 +130,25 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
         onError: (error) => console.log(error),
 
     });
-
+    
+    const {parentIsLoggedIn} = useValidateRegisteringParent();
     const dispatch = useDispatch();
 
     const {studentIdList} = JSON.parse(sessionStorage.getItem("registrations"))?.currentParent || false;
-    const {data, loading, error} = useQuery(GET_STUDENTS_AND_ENROLLMENTS, {
+    const { data: studentEnrollments, loading: studentEnrollmentsLoading, error: studentEnrollmentsError } = useQuery(GET_STUDENTS_AND_ENROLLMENTS, {
         "variables": {"userIds": studentIdList},
         skip: !studentIdList,
     });
 
-    const {parentIsLoggedIn} = useValidateRegisteringParent();
     const {courseTitle, courseRow} = useStyles();
 
-    if (loading) return <Loading small/>;
-    if (error) return <div>There has been an error!</div>;
+    if (studentEnrollmentsLoading) return <Loading small/>;
+    if (studentEnrollmentsError) return <div>There has been an error!</div>;
 
     const validRegistrations = Object.values(registrationCartState)
         .filter(registration => registration);
     const registrations = validRegistrations && [].concat.apply([], validRegistrations);
-    const studentOptions = studentIdList && data.userInfos
+    const studentOptions = studentIdList && studentEnrollments.userInfos
         .filter(({user}) => (!registrations.find(({course, student}) =>
                 (course.id === quickCourseID && user.id === student))
         ))
@@ -157,7 +157,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
             "value": student.user.id,
         })) || [];
 
-    const enrolledCourseIds = data?.enrollments.map(({course}) => course.id);
+    const enrolledCourseIds = studentEnrollments?.enrollments.map(({course}) => course.id);
     const previouslyEnrolled = (courseId, enrolledCourseIds, registrations, studentList) => {
         const validRegistrations = Object.values(registrations)
             .filter(registration => registration);

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -47,6 +47,46 @@ export const GET_STUDENTS_AND_ENROLLMENTS = gql`
     }
 `;
 
+const GET_PARENT_INTEREST = gql`
+    query GetParentInterest($parentId: ID!){
+        interests(parentId: $parentId) {
+            id
+            parent {
+                user {
+                    id
+                    firstName
+                    lastName
+                }
+            }
+            course {
+                id
+                title
+            }
+        }
+    }
+`;
+
+const ADD_PARENT_TO_INTEREST_LIST = gql`
+    mutation AddParentToInterestList($parentId: ID!, $courseId: ID!){
+        createInterest(parent: $parentId, course: $courseId) {
+            interest {
+                id
+                parent {
+                    user {
+                        id
+                        firstName
+                        lastName
+                    }
+                }
+                course {
+                    id
+                    title
+                }
+            }
+        }
+    }
+`;
+
 const useStyles = makeStyles((theme) => ({
     "courseTitle": {
         "color": theme.palette.common.black,

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -10,12 +10,13 @@ import {fullName} from "utils";
 import {useValidateRegisteringParent} from "../../OmouComponents/RegistrationUtils";
 import Box from "@material-ui/core/Box";
 import AddIcon from '@material-ui/icons/Add';
+import CheckIcon from '@material-ui/icons/Check';
 import moment from "moment";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
 import gql from "graphql-tag";
-import {useQuery} from "@apollo/react-hooks";
+import {useMutation, useQuery} from "@apollo/react-hooks";
 import Loading from "../../OmouComponents/Loading";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -26,6 +27,7 @@ import {useDispatch, useSelector} from "react-redux";
 import * as types from "actions/actionTypes";
 import { ResponsiveButton } from '../../../theme/ThemedComponents/Button/ResponsiveButton';
 import ListDetailedItem, { ListContent, ListActions, ListHeading, ListTitle, ListDetails, ListDetail, ListDetailLink, ListButton, ListBadge, ListStatus, ListDivider } from '../../OmouComponents/ListComponent/ListDetailedItem'
+import { buttonBlue, gloom } from "theme/muiTheme";
 
 export const GET_STUDENTS_AND_ENROLLMENTS = gql`
     query GetStudents($userIds: [ID]!) {
@@ -344,6 +346,41 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                     </ ResponsiveButton>
                 </DialogActions>
             </DialogContent>
+        </Dialog>
+        <Dialog open={openInterestDialog} onClose={() => setOpenInterestDialog(false)} PaperProps={{ style: { "height": "310px", "width": "410px", "padding": "32px" } }}>
+            <Grid container spacing={3}>
+                <Grid item>
+                    <Typography variant="h3">Interested?</Typography>
+                </Grid>
+                <Grid item>
+                    <Typography variant="body1">This will add you to the Interest List. You will be notified once a spot opens up. Enrollment is on a first come, first to enroll basis.</Typography>
+                </Grid>
+                <Grid item style={{ "marginBottom": "20px" }}>
+                    <Typography variant="body1">Being on an interest List does not guarantee an actual seat to anyone.</Typography>
+                </Grid>
+                <Grid container justify={"flex-end"}>
+                    <DialogActions>
+                        <ResponsiveButton
+                            data-cy="cancel-add-interest"
+                            onClick={() => setOpenInterestDialog(false)}
+                            variant="outlined"
+                            color="primary"
+                            style={{ border: "none" }}
+                        >
+                            Cancel
+                        </ResponsiveButton>
+                        <ResponsiveButton
+                            data-cy="confirm-add-interest"
+                            onClick={handleAddInterest}
+                            variant="outlined"
+                            color="primary"
+                            style={{ border: "none" }}
+                        >
+                            Notify Me
+                        </ResponsiveButton>
+                    </DialogActions>
+                </Grid>
+            </Grid>
         </Dialog>
         </>
     )

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -154,7 +154,8 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
     const {courseTitle, courseRow} = useStyles();
 
     if (studentEnrollmentsLoading || parentInterestListLoading) return <Loading small/>;
-    if (studentEnrollmentsError || parentInterestError) return <div>There has been an error!</div>;
+    if (studentEnrollmentsError) return <div>There has been an error: {studentEnrollments.message} </div>;
+    if (parentInterestError) return <div>There has been an error: {parentInterestError.message} </div>;
 
     const validRegistrations = Object.values(registrationCartState)
         .filter(registration => registration);

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -101,6 +101,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
     const history = useHistory();
 
     const [openCourseQuickRegistration, setOpenQuickRegister] = useState(false);
+    const [openInterestDialog, setOpenInterestDialog] = useState(false);
     const [quickCourseID, setQuickCourseID] = useState(null);
     const [interestCourseID, setInterestCourseID] = useState(null);
     const [quickStudent, setQuickStudent] = useState("");
@@ -218,9 +219,8 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
         return false;
     }
 
-    const shouldDisableQuickRegister = ({course, enrolledCourseIds, registrations, studentList}) => {
-        return ((course.maxCapacity <= course.enrollmentSet.length) &&
-            (previouslyEnrolled(course.id, enrolledCourseIds, registrations, studentList)))
+    const shouldDisableQuickRegister = ({ course, enrolledCourseIds, registrations, studentList }) => {
+        return ((previouslyEnrolled(course.id, enrolledCourseIds, registrations, studentList)))
     }
 
 
@@ -274,18 +274,40 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                                 {course.enrollmentSet.length} / {course.maxCapacity}
                             </ListStatus>
                             <ListButton>
-                                <ResponsiveButton
-                                    disabled={shouldDisableQuickRegister({
-                                        course, enrolledCourseIds,
-                                        registrations, studentIdList
-                                    })}                                    
-                                    variant="contained"
-                                    onClick={handleStartQuickRegister(course.id)}
-                                    data-cy="quick-register-class"
-                                    startIcon={<AddIcon />}
-                                >
-                                    register
-                                </ResponsiveButton>
+                                {course.enrollmentSet.length < course.maxCapacity
+                                    ? <ResponsiveButton
+                                        disabled={shouldDisableQuickRegister({
+                                            course, enrolledCourseIds,
+                                            registrations, studentIdList
+                                        })}
+                                        variant="contained"
+                                        onClick={handleStartQuickRegister(course.id)}
+                                        data-cy="quick-register-class"
+                                        startIcon={<AddIcon />}
+                                    >
+                                        register
+                                    </ResponsiveButton>
+                                    : inParentInterestList(course.id)
+                                        ? <ResponsiveButton
+                                            disabled={inParentInterestList(course.id)}
+                                            variant="outlined"
+                                            onClick={handleInterestRegister(course.id)}
+                                            data-cy="add-interest-button"
+                                            style={{ color: buttonBlue, border: "none", background: white }}
+                                            startIcon={<CheckIcon />}
+                                        >
+                                            interested
+                                        </ResponsiveButton>
+                                        : <ResponsiveButton
+                                            disabled={inParentInterestList(course.id)}
+                                            variant="outlined"
+                                            onClick={handleInterestRegister(course.id)}
+                                            data-cy="add-interest-button"
+                                            style={{ color: gloom }}
+                                            startIcon={<AddIcon />}
+                                        >
+                                            interest
+                                        </ResponsiveButton>}
                             </ListButton>
                         </ListActions>
                     </ListDetailedItem>)

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -117,12 +117,12 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
         },
         update: (cache, { data }) => {
             const newInterest = data.createInterest.interest;
-            console.log(newInterest)
+            
             const cachedInterestList = cache.readQuery({
                 query: GET_PARENT_INTEREST,
                 variables: { "parentId": currentParent.user.id },
             }).interests;
-            console.log(cachedInterestList);
+           
             cache.writeQuery({
                 data: {
                     interests: [...cachedInterestList, newInterest],
@@ -200,7 +200,6 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
 
     const handleInterestRegister = (courseID) => (e) => {
         e.preventDefault();
-        console.log("Hello");
         setInterestCourseID(courseID);
         setOpenInterestDialog(true);
 

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -102,9 +102,35 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
 
     const [openCourseQuickRegistration, setOpen] = useState(false);
     const [quickCourseID, setQuickCourseID] = useState(null);
+    const [interestCourseID, setInterestCourseID] = useState(null);
     const [quickStudent, setQuickStudent] = useState("");
 
     const {currentParent, ...registrationCartState} = useSelector((state) => state.Registration);
+    const [addParentToInterestList, addParentToInterestListStatus] = useMutation(ADD_PARENT_TO_INTEREST_LIST, {
+
+        onCompleted: () => {
+            setOpenInterestDialog(false);
+        },
+        update: (cache, { data }) => {
+            const newInterest = data.createInterest.interest;
+            console.log(newInterest)
+            const cachedInterestList = cache.readQuery({
+                query: GET_PARENT_INTEREST,
+                variables: { "parentId": currentParent.user.id },
+            }).interests;
+            console.log(cachedInterestList);
+            cache.writeQuery({
+                data: {
+                    interests: [...cachedInterestList, newInterest],
+                },
+                query: GET_PARENT_INTEREST,
+                variables: { "parentId": currentParent.user.id },
+            });
+        },
+        onError: (error) => console.log(error),
+
+    });
+
     const dispatch = useDispatch();
 
     const {studentIdList} = JSON.parse(sessionStorage.getItem("registrations"))?.currentParent || false;

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -140,10 +140,17 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
         skip: !studentIdList,
     });
 
+    const { data: parentInterestList, loading: parentInterestListLoading, error: parentInterestError } = useQuery(GET_PARENT_INTEREST, {
+        "variables": {
+            "parentId": currentParent?.user.id,
+        },
+        skip: !parentIsLoggedIn,
+    })
+
     const {courseTitle, courseRow} = useStyles();
 
-    if (studentEnrollmentsLoading) return <Loading small/>;
-    if (studentEnrollmentsError) return <div>There has been an error!</div>;
+    if (studentEnrollmentsLoading || parentInterestListLoading) return <Loading small/>;
+    if (studentEnrollmentsError || parentInterestError) return <div>There has been an error!</div>;
 
     const validRegistrations = Object.values(registrationCartState)
         .filter(registration => registration);

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -240,7 +240,6 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
             .filter(({courseType, endDate, id}) => ((courseType === "CLASS") &&
                     (moment().diff(moment(endDate), 'days') < 0)))
             .map((course) => {
-                course.enrollmentSet.length = course.maxCapacity;
                 return(
                     <ListDetailedItem
                         key={course.id}

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -100,7 +100,7 @@ const useStyles = makeStyles((theme) => ({
 const CourseList = ({ filteredCourses, updatedParent }) => {
     const history = useHistory();
 
-    const [openCourseQuickRegistration, setOpen] = useState(false);
+    const [openCourseQuickRegistration, setOpenQuickRegister] = useState(false);
     const [quickCourseID, setQuickCourseID] = useState(null);
     const [interestCourseID, setInterestCourseID] = useState(null);
     const [quickStudent, setQuickStudent] = useState("");
@@ -179,7 +179,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
 
     const handleStartQuickRegister = (courseID) => (e) => {
         e.preventDefault();
-        setOpen(true);
+        setOpenQuickRegister(true);
         setQuickCourseID(courseID);
     };
 
@@ -191,7 +191,31 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                 courseId: quickCourseID
             }
         });
-        setOpen(false);
+        setOpenQuickRegister(false);
+    }
+
+    const handleInterestRegister = (courseID) => (e) => {
+        e.preventDefault();
+        setInterestCourseID(courseID);
+        setOpenInterestDialog(true);
+
+    }
+
+    const handleAddInterest = () => {
+
+        addParentToInterestList({
+            variables: {
+                "parentId": currentParent.user.id,
+                "courseId": interestCourseID,
+            }
+        })
+    }
+
+    const inParentInterestList = (courseID) => {
+        if (parentInterestList) {
+            return parentInterestList.interests.some((interest) => interest.course.id === courseID);
+        }
+        return false;
     }
 
     const shouldDisableQuickRegister = ({course, enrolledCourseIds, registrations, studentList}) => {
@@ -268,7 +292,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                                         })
         }
         </Box>
-        <Dialog open={openCourseQuickRegistration} onClose={() => setOpen(false)}>
+        <Dialog open={openCourseQuickRegistration} onClose={() => setOpenQuickRegister(false)}>
             <DialogTitle>Which student do you want to enroll?</DialogTitle>
             <DialogContent>
                 <FormControl fullWidth variant="outlined">

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -247,7 +247,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
             .filter(({courseType, endDate, id}) => ((courseType === "CLASS") &&
                     (moment().diff(moment(endDate), 'days') < 0)))
             .map((course) => {
-                course.enrollmentSet.length = course.maxCapacity
+                
                 return(
                     <ListDetailedItem
                         key={course.id}

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -10,13 +10,12 @@ import {fullName} from "utils";
 import {useValidateRegisteringParent} from "../../OmouComponents/RegistrationUtils";
 import Box from "@material-ui/core/Box";
 import AddIcon from '@material-ui/icons/Add';
-import CheckIcon from '@material-ui/icons/Check';
 import moment from "moment";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
 import gql from "graphql-tag";
-import {useMutation, useQuery} from "@apollo/react-hooks";
+import {useQuery} from "@apollo/react-hooks";
 import Loading from "../../OmouComponents/Loading";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -27,7 +26,6 @@ import {useDispatch, useSelector} from "react-redux";
 import * as types from "actions/actionTypes";
 import { ResponsiveButton } from '../../../theme/ThemedComponents/Button/ResponsiveButton';
 import ListDetailedItem, { ListContent, ListActions, ListHeading, ListTitle, ListDetails, ListDetail, ListDetailLink, ListButton, ListBadge, ListStatus, ListDivider } from '../../OmouComponents/ListComponent/ListDetailedItem'
-import { buttonBlue, gloom } from "theme/muiTheme";
 
 export const GET_STUDENTS_AND_ENROLLMENTS = gql`
     query GetStudents($userIds: [ID]!) {
@@ -346,41 +344,6 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                     </ ResponsiveButton>
                 </DialogActions>
             </DialogContent>
-        </Dialog>
-        <Dialog open={openInterestDialog} onClose={() => setOpenInterestDialog(false)} PaperProps={{ style: { "height": "310px", "width": "410px", "padding": "32px" } }}>
-            <Grid container spacing={3}>
-                <Grid item>
-                    <Typography variant="h3">Interested?</Typography>
-                </Grid>
-                <Grid item>
-                    <Typography variant="body1">This will add you to the Interest List. You will be notified once a spot opens up. Enrollment is on a first come, first to enroll basis.</Typography>
-                </Grid>
-                <Grid item style={{ "marginBottom": "20px" }}>
-                    <Typography variant="body1">Being on an interest List does not guarantee an actual seat to anyone.</Typography>
-                </Grid>
-                <Grid container justify={"flex-end"}>
-                    <DialogActions>
-                        <ResponsiveButton
-                            data-cy="cancel-add-interest"
-                            onClick={() => setOpenInterestDialog(false)}
-                            variant="outlined"
-                            color="primary"
-                            style={{ border: "none" }}
-                        >
-                            Cancel
-                        </ResponsiveButton>
-                        <ResponsiveButton
-                            data-cy="confirm-add-interest"
-                            onClick={handleAddInterest}
-                            variant="outlined"
-                            color="primary"
-                            style={{ border: "none" }}
-                        >
-                            Notify Me
-                        </ResponsiveButton>
-                    </DialogActions>
-                </Grid>
-            </Grid>
         </Dialog>
         </>
     )

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -10,12 +10,13 @@ import {fullName} from "utils";
 import {useValidateRegisteringParent} from "../../OmouComponents/RegistrationUtils";
 import Box from "@material-ui/core/Box";
 import AddIcon from '@material-ui/icons/Add';
+import CheckIcon from '@material-ui/icons/Check';
 import moment from "moment";
 import Dialog from "@material-ui/core/Dialog";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import DialogContent from "@material-ui/core/DialogContent";
 import gql from "graphql-tag";
-import {useQuery} from "@apollo/react-hooks";
+import {useMutation, useQuery} from "@apollo/react-hooks";
 import Loading from "../../OmouComponents/Loading";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -26,6 +27,8 @@ import {useDispatch, useSelector} from "react-redux";
 import * as types from "actions/actionTypes";
 import { ResponsiveButton } from '../../../theme/ThemedComponents/Button/ResponsiveButton';
 import ListDetailedItem, { ListContent, ListActions, ListHeading, ListTitle, ListDetails, ListDetail, ListDetailLink, ListButton, ListBadge, ListStatus, ListDivider } from '../../OmouComponents/ListComponent/ListDetailedItem'
+import { buttonBlue, gloom, white } from "theme/muiTheme";
+import { Grid } from "@material-ui/core";
 
 export const GET_STUDENTS_AND_ENROLLMENTS = gql`
     query GetStudents($userIds: [ID]!) {
@@ -197,6 +200,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
 
     const handleInterestRegister = (courseID) => (e) => {
         e.preventDefault();
+        console.log("Hello");
         setInterestCourseID(courseID);
         setOpenInterestDialog(true);
 
@@ -220,7 +224,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
     }
 
     const shouldDisableQuickRegister = ({ course, enrolledCourseIds, registrations, studentList }) => {
-        return ((previouslyEnrolled(course.id, enrolledCourseIds, registrations, studentList)))
+        return (course.enrollmentSet.length === course.maxCapacity || (previouslyEnrolled(course.id, enrolledCourseIds, registrations, studentList)))
     }
 
 
@@ -236,6 +240,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
             .filter(({courseType, endDate, id}) => ((courseType === "CLASS") &&
                     (moment().diff(moment(endDate), 'days') < 0)))
             .map((course) => {
+                course.enrollmentSet.length = course.maxCapacity;
                 return(
                     <ListDetailedItem
                         key={course.id}
@@ -274,7 +279,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                                 {course.enrollmentSet.length} / {course.maxCapacity}
                             </ListStatus>
                             <ListButton>
-                                {course.enrollmentSet.length < course.maxCapacity
+                                {course.enrollmentSet.length < course.maxCapacity || !parentIsLoggedIn
                                     ? <ResponsiveButton
                                         disabled={shouldDisableQuickRegister({
                                             course, enrolledCourseIds,
@@ -345,6 +350,42 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                 </DialogActions>
             </DialogContent>
         </Dialog>
+        <Dialog open={openInterestDialog} onClose={() => setOpenInterestDialog(false)} PaperProps={{ style: { "height": "310px", "width": "410px", "padding": "32px" } }}>
+                <Grid container spacing={3}>
+                    <Grid item>
+                        <Typography variant="h3">Interested?</Typography>
+                    </Grid>
+                    <Grid item>
+                        <Typography variant="body1">This will add you to the Interest List. You will be notified once a spot opens up. Enrollment is on a first come, first to enroll basis.</Typography>
+                    </Grid>
+                    <Grid item style={{ "marginBottom": "20px" }}>
+                        <Typography variant="body1">Being on an interest List does not guarantee an actual seat to anyone.</Typography>
+                    </Grid>
+                    <Grid container justify={"flex-end"}>
+                        <DialogActions>
+                            <ResponsiveButton
+                                data-cy="cancel-add-interest"
+                                onClick={() => setOpenInterestDialog(false)}
+                                variant="outlined"
+                                color="primary"
+                                style={{ border: "none" }}
+                            >
+                                Cancel
+                            </ResponsiveButton>
+                            <ResponsiveButton
+                                data-cy="confirm-add-interest"
+                                onClick={handleAddInterest}
+                                variant="outlined"
+                                color="primary"
+                                style={{ border: "none" }}
+                            >
+                                Notify Me
+                            </ResponsiveButton>
+                        </DialogActions>
+                    </Grid>
+
+                </Grid>
+            </Dialog>
         </>
     )
 };

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -28,7 +28,7 @@ import * as types from "actions/actionTypes";
 import { ResponsiveButton } from '../../../theme/ThemedComponents/Button/ResponsiveButton';
 import ListDetailedItem, { ListContent, ListActions, ListHeading, ListTitle, ListDetails, ListDetail, ListDetailLink, ListButton, ListBadge, ListStatus, ListDivider } from '../../OmouComponents/ListComponent/ListDetailedItem'
 import { buttonBlue, gloom, white } from "theme/muiTheme";
-import { Grid } from "@material-ui/core";
+import { DialogContentText, Grid } from "@material-ui/core";
 import ParentCourseInterestBtn from "./ParentCourseInterestBtn";
 
 export const GET_STUDENTS_AND_ENROLLMENTS = gql`
@@ -99,6 +99,12 @@ const useStyles = makeStyles((theme) => ({
     "courseRow": {
         textDecoration: "none"
     },
+    "interestDialogHeading": {
+        paddingLeft: "0px"
+    },
+    "interestDialogText": {
+        marginBottom: "20px"
+    }
 }));
 
 const CourseList = ({ filteredCourses, updatedParent }) => {
@@ -152,7 +158,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
         skip: !parentIsLoggedIn,
     })
 
-    const {courseTitle, courseRow} = useStyles();
+    const classes = useStyles();
 
     if (studentEnrollmentsLoading || parentInterestListLoading) return <Loading small/>;
     if (studentEnrollmentsError) return <div>There has been an error: {studentEnrollments.message} </div>;
@@ -340,40 +346,36 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
             open={openInterestDialog} 
             onClose={() => setOpenInterestDialog(false)} 
             PaperProps={{ style: { "height": "310px", "width": "410px", "padding": "32px" } }}>
-                <Grid container spacing={3}>
-                    <Grid item>
-                        <Typography variant="h3">Interested?</Typography>
-                    </Grid>
-                    <Grid item>
-                        <Typography variant="body1">This will add you to the Interest List. You will be notified once a spot opens up. Enrollment is on a first come, first to enroll basis.</Typography>
-                    </Grid>
-                    <Grid item style={{ "marginBottom": "20px" }}>
-                        <Typography variant="body1">Being on an interest List does not guarantee an actual seat to anyone.</Typography>
-                    </Grid>
-                    <Grid container justify={"flex-end"}>
-                        <DialogActions>
-                            <ResponsiveButton
-                                data-cy="cancel-add-interest"
-                                onClick={() => setOpenInterestDialog(false)}
-                                variant="outlined"
-                                color="primary"
-                                style={{ border: "none" }}
-                            >
-                                Cancel
-                            </ResponsiveButton>
-                            <ResponsiveButton
-                                data-cy="confirm-add-interest"
-                                onClick={handleAddInterest}
-                                variant="outlined"
-                                color="primary"
-                                style={{ border: "none" }}
-                            >
-                                Notify Me
-                            </ResponsiveButton>
-                        </DialogActions>
-                    </Grid>
-
-                </Grid>
+                
+            <DialogTitle disableTypography className={classes.interestDialogHeading}>
+                <Typography variant="h3">Interested?</Typography>
+            </DialogTitle>
+            <DialogContentText classname={classes.interestDialogText}>
+                <Typography variant="body1">This will add you to the Interest List. You will be notified once a spot opens up. Enrollment is on a first come, first to enroll basis.</Typography>
+            </DialogContentText>
+            <DialogContentText item classname={classes.interestDialogText}>
+                <Typography variant="body1">Being on an interest List does not guarantee an actual seat to anyone.</Typography>
+            </DialogContentText>
+            <DialogActions>
+                <ResponsiveButton
+                    data-cy="cancel-add-interest"
+                    onClick={() => setOpenInterestDialog(false)}
+                    variant="outlined"
+                    color="primary"
+                    style={{ border: "none" }}
+                >
+                    Cancel
+                </ResponsiveButton>
+                <ResponsiveButton
+                    data-cy="confirm-add-interest"
+                    onClick={handleAddInterest}
+                    variant="outlined"
+                    color="primary"
+                    style={{ border: "none" }}
+                >
+                    Notify Me
+                </ResponsiveButton>
+            </DialogActions>
             </Dialog>
         </>
     )

--- a/src/components/FeatureViews/Registration/CourseList.js
+++ b/src/components/FeatureViews/Registration/CourseList.js
@@ -29,6 +29,7 @@ import { ResponsiveButton } from '../../../theme/ThemedComponents/Button/Respons
 import ListDetailedItem, { ListContent, ListActions, ListHeading, ListTitle, ListDetails, ListDetail, ListDetailLink, ListButton, ListBadge, ListStatus, ListDivider } from '../../OmouComponents/ListComponent/ListDetailedItem'
 import { buttonBlue, gloom, white } from "theme/muiTheme";
 import { Grid } from "@material-ui/core";
+import ParentCourseInterestBtn from "./ParentCourseInterestBtn";
 
 export const GET_STUDENTS_AND_ENROLLMENTS = gql`
     query GetStudents($userIds: [ID]!) {
@@ -240,6 +241,7 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
             .filter(({courseType, endDate, id}) => ((courseType === "CLASS") &&
                     (moment().diff(moment(endDate), 'days') < 0)))
             .map((course) => {
+                course.enrollmentSet.length = course.maxCapacity
                 return(
                     <ListDetailedItem
                         key={course.id}
@@ -291,27 +293,12 @@ const CourseList = ({ filteredCourses, updatedParent }) => {
                                     >
                                         register
                                     </ResponsiveButton>
-                                    : isCourseOnParentInterestList(course.id)
-                                        ? <ResponsiveButton
-                                            disabled={isCourseOnParentInterestList(course.id)}
-                                            variant="outlined"
-                                            onClick={handleInterestRegister(course.id)}
-                                            data-cy="add-interest-button"
-                                            style={{ color: buttonBlue, border: "none", background: white }}
-                                            startIcon={<CheckIcon />}
-                                        >
-                                            interested
-                                        </ResponsiveButton>
-                                        : <ResponsiveButton
-                                            disabled={isCourseOnParentInterestList(course.id)}
-                                            variant="outlined"
-                                            onClick={handleInterestRegister(course.id)}
-                                            data-cy="add-interest-button"
-                                            style={{ color: gloom }}
-                                            startIcon={<AddIcon />}
-                                        >
-                                            interest
-                                        </ResponsiveButton>}
+                                    :<ParentCourseInterestBtn 
+                                        courseID ={course.id}
+                                        isCourseOnParentInterestList={isCourseOnParentInterestList}
+                                        handleInterestRegister={handleInterestRegister}
+                                        />
+                                }
                             </ListButton>
                         </ListActions>
                     </ListDetailedItem>)

--- a/src/components/FeatureViews/Registration/ParentCourseInterestBtn.js
+++ b/src/components/FeatureViews/Registration/ParentCourseInterestBtn.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { buttonBlue, gloom, white } from "theme/muiTheme";
+import { ResponsiveButton } from "theme/ThemedComponents/Button/ResponsiveButton";
+import AddIcon from '@material-ui/icons/Add';
+import CheckIcon from '@material-ui/icons/Check';
+
+const ParentCourseInterestBtn = ({ courseID, isCourseOnParentInterestList, handleInterestRegister }) => {
+    console.log(isCourseOnParentInterestList);
+    
+    return (isCourseOnParentInterestList(courseID)
+    ? <ResponsiveButton
+        disabled={true}
+        variant="outlined"
+        data-cy="add-interest-button"
+        style={{ color: buttonBlue, border: "none", background: white }}
+        startIcon={<CheckIcon />}
+    >
+        interested
+    </ResponsiveButton>
+    : <ResponsiveButton
+        variant="outlined"
+        onClick={handleInterestRegister(courseID)}
+        data-cy="add-interest-button"
+        style={{ color: gloom }}
+        startIcon={<AddIcon />}
+    >
+        interest
+    </ResponsiveButton>)
+}
+
+export default ParentCourseInterestBtn;


### PR DESCRIPTION
# Goal
Add option for parent to add class to their interest list if the course is fully enrolled.

## Changes
- When Parent is logged in and views the Registration View
    - The parent's interest list is queried for
    - If course is full and not already on interest list, REGISTER button is replaced with INTEREST button
    - When parent clicks on INTEREST button a modal pops up with two options
        - CANCEL closes the popup
        - NOTIFY ME sends a mutation adding the parent to the course that was clicked on, then cache is updated
    - If the Parent is on the interest list then the INTEREST button is replaced with INTERESTED with a check in front

## Screen Shots
![image](https://user-images.githubusercontent.com/16299570/101261598-6b489500-36ed-11eb-9b93-fdcd08c1e68f.png)
![image](https://user-images.githubusercontent.com/16299570/101261607-756a9380-36ed-11eb-9e2f-ef11ac914a41.png)
![image](https://user-images.githubusercontent.com/16299570/101261616-7c91a180-36ed-11eb-8dc5-cb4fbbacabde.png)
![image](https://user-images.githubusercontent.com/16299570/101261623-83201900-36ed-11eb-9699-91e01d1613e3.png)
![image](https://user-images.githubusercontent.com/16299570/101261627-8915fa00-36ed-11eb-897f-d3a12e806e01.png)



