### PR TITLE
changed route of add admin action from registration form to admin form

### DIFF
--- a/src/components/FeatureViews/AdminPortal/AdminActionCenter.js
+++ b/src/components/FeatureViews/AdminPortal/AdminActionCenter.js
@@ -138,7 +138,7 @@ const AdminActionCenter = () => {
 				<MenuItem component={NavLink} to="/form/instructor">
 					<ListItemText primary="ADD INSTRUCTOR"/>
 				</MenuItem>
-				<MenuItem component={NavLink} to="/registration/form/admin">
+				<MenuItem component={NavLink} to="/form/admin">
 					<ListItemText primary="ADD ADMIN" />
 				</MenuItem>
 			</StyledMenu>


### PR DESCRIPTION
Changed route of add admin action to go to admin form instead of registration form. This solves the issue of having a 400 code rendered on the UI even when admin is successfully created