### PR TITLE
Add item note height

### DIFF
--- a/src/components/FeatureViews/Accounts/ComponentViewer.js
+++ b/src/components/FeatureViews/Accounts/ComponentViewer.js
@@ -102,7 +102,7 @@ const ComponentViewer = ({ inView, user, id }) => {
                 },
                 {
                     component: (
-                        <Notes ownerID={id} ownerType="account" isProfile={true} key={7} />
+                        <Notes ownerID={id} ownerType="account" key={7} />
                     ),
                     access_permissions: [
                         USER_TYPES.receptionist,

--- a/src/components/FeatureViews/Notes/Notes.js
+++ b/src/components/FeatureViews/Notes/Notes.js
@@ -23,7 +23,7 @@ import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import IconButton from "@material-ui/core/IconButton";
 import Tooltip from "@material-ui/core/Tooltip";
-
+import ReadMoreText from "components/OmouComponents/ReadMoreText";
 import {ResponsiveButton} from '../../../theme/ThemedComponents/Button/ResponsiveButton'
 
 import "./Notes.scss";
@@ -605,19 +605,21 @@ const Notes = ({ ownerType, ownerID, isDashboard }) => {
             {notes && isDashboard && Object.values(notes).map((note) => (
                 <Grid item key={note.id || note.body} xs={12}>
                     <Paper className={`note ${classes.notePaper}`} elevation={2} >
+                        <Avatar
+                            variant="square"
+                            className={`noteNotification ${isDashboard ? classes.notesNotification : null}`}
+                            onClick={toggleNoteField(note.id, "important")}
+                            style={note.important ? { "background-color": "red" } : {}}>
+                            !
+                        </Avatar>
                         <Typography align="left"
                             className={`noteHeader ${classes.notesTitle}`}>
                             {note.title}
-                            <Avatar
-                                variant="square"
-                                className={`noteNotification ${isDashboard ? classes.notesNotification : null}`}
-                                onClick={toggleNoteField(note.id, "important")}
-                                style={note.important ? { "background-color": "red" } : {}}>
-                                !
-                            </Avatar>
                         </Typography>
                         <Typography align="left" className="body">
-                            {note.body}
+                            <ReadMoreText textLimit={30} handleDisplay={openExistingNote(note)}>
+                                {note.body}
+                            </ReadMoreText>
                         </Typography>
                         <Grid item xs={12}>
                             <Typography className={`date ${classes.dateDisplay}`}

--- a/src/components/FeatureViews/Notes/Notes.js
+++ b/src/components/FeatureViews/Notes/Notes.js
@@ -230,7 +230,8 @@ const MUTATION_KEY = {
 };
 
 // eslint-disable-next-line max-statements
-const Notes = ({ ownerType, ownerID, isDashboard, isProfile = false }) => {
+// Jan 29, 2021 - Plan to refactor Dashboard notes
+const Notes = ({ ownerType, ownerID, isDashboard }) => {
     const dispatch = useDispatch();
 
     const [alert, setAlert] = useState(false);
@@ -341,16 +342,6 @@ const Notes = ({ ownerType, ownerID, isDashboard, isProfile = false }) => {
         setDeleteID(null);
         setDeleteError(false);
     }, []);
-
-    const getNoteHeight = (type = '') => {
-        switch (type) {
-            case 'dashboard':
-            case 'profile': 
-                return '250px';
-            default:
-                return '200px';
-        }
-    }
 
     const notificationColor = useMemo(() => ({
         "color": important ? "red" : "grey",
@@ -589,7 +580,7 @@ const Notes = ({ ownerType, ownerID, isDashboard, isProfile = false }) => {
                                 item
                                 xs={12}>
                                 <AddItemButton
-                                    height={getNoteHeight('dashboard')}
+                                    height={'50px'}
                                     width='inherit'
                                     style={{padding: 0}}
                                     onClick={openNewNote}

--- a/src/components/OmouComponents/ReadMoreText.js
+++ b/src/components/OmouComponents/ReadMoreText.js
@@ -1,0 +1,49 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography'
+import theme from "../../theme/muiTheme";
+
+const ReadMoreText = ({children, textLimit, handleDisplay = null}) => {
+
+    const [isReadMoreClosed, setReadMore] = useState(true);
+    const handleReadMoreClick = () => {
+        console.log(handleDisplay);
+        if (handleDisplay !== null) {
+            handleDisplay();
+        } else {
+            setReadMore(!isReadMoreClosed);
+        }
+    }
+    const bodyText = children;
+    const isOverTextLimit = (children.length > textLimit);
+
+    if(isOverTextLimit){
+        return (
+            <Typography variant="body1" align="left" style={{ wordBreak: "break-word" }}>
+                {isReadMoreClosed ? bodyText.substring(0, textLimit) + "...\n" : bodyText + "\n"}
+                <a onClick={handleReadMoreClick}>
+                    <span style={{ paddingRight: theme.spacing(1) }}>
+                        { isReadMoreClosed ? "Read More" : " Read Less" }
+                    </span>
+                </a>
+            </Typography>
+        );
+        
+    }
+    else {
+        return (
+            <Typography variant="body1" align="left" style={{ wordBreak: "break-word" }}>
+                {bodyText}
+            </Typography>
+        )
+    }
+
+}
+
+ReadMoreText.propTypes = {
+    children : PropTypes.string.isRequired,
+    textLimit : PropTypes.number.isRequired,
+    handleDisplay: PropTypes.func 
+};
+
+export default ReadMoreText;


### PR DESCRIPTION
## Goals
- Fix dashboard add button height
- Reimplement ReadMoreText component from PR #616 

### Changes
Made Dashboard addItemButton 50px
Copied ReadMoreText from PR #616 
Added prop to ReadMoreText to pass in custom function to run when Read More is clicked.

### Screenshots
When note is too long for note
![image](https://user-images.githubusercontent.com/16299570/106323168-d2855000-622b-11eb-87fa-d8cc057d1a95.png)

When Read More is clicked
![image](https://user-images.githubusercontent.com/16299570/106323235-ed57c480-622b-11eb-96cb-3c49a7ef8d5d.png)
