### PR TITLE
removed 2px border caused element to resize on hover

### DIFF
--- a/src/theme/muiTheme.js
+++ b/src/theme/muiTheme.js
@@ -187,7 +187,7 @@ const theme = createMuiTheme({
                 '&:hover': {
                     backgroundColor: buttonBlue,
                     opacity: '80%',
-                    border: 'rgba(40, 159, 195, 0.8)',
+                    border: '2px solid rgba(40, 159, 195, 0.8)',
                     '-webkit-background-clip': 'padding-box',
                     'background-clip': 'padding-box',
                 },


### PR DESCRIPTION
If you look at the contained button theme we defined border with a 2px as the default.

When adding the style to "&:hover" on the contained property - we never added 2px solid so the hover just adds its own border.

Did we want the border or not?

Fix 1 : remove border in default contained prop.
```  
border: `2px solid ${buttonBlue}`,
```
Fix 2 : Add 2px solid on hover 
```
    border: '2px solid rgba(40, 159, 195, 0.8)',
```

fixes #710 